### PR TITLE
Build storybook as part of PR build

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -21,6 +21,8 @@ jobs:
         run: npm run jest
       - name: Webpack compile everything
         run: webpack
+      - name: Build storybook
+        run: yarn build-storybook
       - name: build package locally
         run: yarn pack
       - name: Archive the output of yarn pack

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,6 +24,8 @@ jobs:
         run: npm run jest
       - name: Webpack compile everything
         run: npm run webpack
+      - name: Build storybook
+        run: yarn build-storybook
 
   publish-npm:
     needs: build


### PR DESCRIPTION
Currently, builds don't build the storybook. That's important because we want to make sure we can reuse the Webpack setup between both.