### PR TITLE
Switch to using the latest v1 version of noticeme

### DIFF
--- a/NOTICE-js
+++ b/NOTICE-js
@@ -1752,8 +1752,7 @@ Copyright 2014-present Facebook, Inc.
 ** spdx-correct; version 3.1.1 -- https://github.com/jslicense/spdx-correct.js#readme
 ** validate-npm-package-license; version 3.0.4 -- https://github.com/kemitchell/validate-npm-package-license.js#readme
 
-
-                                 Apache License
+Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
@@ -1933,7 +1932,7 @@ Copyright 2014-present Facebook, Inc.
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
+      boilerplate notice, with the fields enclosed by brackets "{}"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -1941,7 +1940,7 @@ Copyright 2014-present Facebook, Inc.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright {yyyy} {name of copyright owner}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -1954,6 +1953,7 @@ Copyright 2014-present Facebook, Inc.
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
 
 
 ------
@@ -11241,6 +11241,7 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ------
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "webpack": "webpack",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "notice": "yarn dlx @houdiniproject/noticeme@^1.1.0-pre1 -f NOTICE-js -i included.json",
-    "notice_update": "yarn dlx @houdiniproject/noticeme@^1.1.0-pre1 -f NOTICE-js -i included.json -u"
+    "notice": "yarn dlx @houdiniproject/noticeme@^1 -f NOTICE-js -i included.json",
+    "notice_update": "yarn dlx @houdiniproject/noticeme@^1 -f NOTICE-js -i included.json -u"
   },
   "author": "Houdini Project contributors, react-currency-input contributors and Cedric Dugas",
   "license": "LGPL-3.0+",


### PR DESCRIPTION
We're now less specific about the version of noticeme we're going to use. We use the latest v1 version of noticeme.
